### PR TITLE
OR-37 | Dockerize Sidekiq Service Run separately(Prod)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     nori (2.6.0)
     oj (3.10.18)
     orm_adapter (0.5.0)
@@ -303,8 +305,6 @@ GEM
     rake (13.0.6)
     rdoc (5.1.0)
     redis (4.2.5)
-    redis-client (0.17.0)
-      connection_pool
     regexp_parser (2.8.1)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -373,11 +373,10 @@ GEM
     sdoc (2.0.4)
       rdoc (>= 5.0)
     selectize-rails (0.12.6)
-    sidekiq (7.1.5)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.14.0)
+    sidekiq (6.5.1)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     sidekiq-cron (1.10.1)
       fugit (~> 1.8)
       globalid (>= 1.0.1)
@@ -398,6 +397,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.6-x86_64-darwin)
+    sqlite3 (1.6.6-x86_64-linux)
     sshkit (1.21.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -446,6 +446,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   administrate (~> 0.19.0)
@@ -489,7 +490,7 @@ DEPENDENCIES
   sass-rails (~> 6.0)
   savon (= 2.12.1)
   sdoc (~> 2.0.3)
-  sidekiq
+  sidekiq (< 7)
   sidekiq-cron
   simplecov (= 0.21.2)
   sprockets (~> 4.0)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,9 +43,26 @@ services:
       - /etc/ssl/certs:/etc/nginx/certs
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./nginx.conf:/etc/nginx/conf.d/nginx.conf
+  
+  redis:
+    image: redis
+    ports:
+      - '6379:6379'
+
+  sidekiq:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    command: bundle exec sidekiq
+    entrypoint: docker/sidekiq-entrypoint.sh
+    links:
+      - db
+      - redis
+    env_file:
+      - .env     
   frontend:
      image: chucksalem/oceano-frontend
-
+  
 
 volumes:
   db:

--- a/docker/sidekiq-entrypoint.sh
+++ b/docker/sidekiq-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+
+service redis-server start &
+bundle check || bundle install
+bundle exec sidekiq


### PR DESCRIPTION
## Describe your changes
- Dockerized Sidekiq Service to run Separately for Prod. 
- CherryPicked changes from [this branch](https://github.com/chucksalem/oceano_2022_backend/tree/OR-37-Dockerize-Sidekiq-Service) as Staging and Prod Server aren't synced and they cant be merged with each other.

## Issue ticket number and link
[OR-37](https://oceano-rentals.atlassian.net/browse/OR-37)
## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.


